### PR TITLE
feat(ui): pt-BR status_pt + HTTP seam test for trials table (#46)

### DIFF
--- a/tests/test_ui_dashboard.py
+++ b/tests/test_ui_dashboard.py
@@ -1,0 +1,144 @@
+"""HTTP seam + pt-BR localization for the dashboard (issue #46).
+
+Verifies the live ``/api/status`` endpoint localizes Trial Status server-side:
+the canonical English ``status`` stays intact in the payload while a new
+``status_pt`` presentation field carries the pt-BR label (ADR 0006 / CONTEXT.md).
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import threading
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from autoresearch.runners import run as run_mod
+from ui import trial_reader
+
+_HEADER = run_mod.CATEGORY_FIELDNAMES
+
+# (canonical status, pt-BR label, pill color) — one entry per ADR 0006 status.
+_STATUS_PT: list[tuple[str, str, str]] = [
+    ("on_front", "na fronteira", "#0a7a2f"),
+    ("dominated", "dominado", "#666666"),
+    ("incomplete", "incompleto", "#b8860b"),
+    ("rejected", "rejeitado", "#d70018"),
+]
+
+
+def _write_results(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=_HEADER, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _sample_rows() -> list[dict[str, str]]:
+    """One row per canonical status with the columns the UI renders."""
+    rows = []
+    for status, _label, _color in _STATUS_PT:
+        rows.append(
+            {
+                "outcome": "OK" if status != "rejected" else "MODEL_REJECTED",
+                "diagnostic": f"{status} diagnostic",
+                "status": status,
+                "agentic": "0.8000",
+                "coding": "0.650000",
+                "memory_gb": "6.2",
+                "elapsed_sec": "180",
+                "tps": "42.5",
+                "ctx": "32768",
+                "description": f"Ornith 1.5 35B ctx32k [{status}]",
+            }
+        )
+    return rows
+
+
+@contextmanager
+def _live_server(tmp_path: Path, rows: list[dict[str, str]]) -> str:
+    """Serve the real DashboardHandler with a temporary results.tsv."""
+    from http.server import ThreadingHTTPServer
+
+    from ui.server import DashboardHandler
+
+    results = tmp_path / "results.tsv"
+    _write_results(results, rows)
+    with mock.patch.object(run_mod, "RESULTS_FILE", results):
+        server = ThreadingHTTPServer(("127.0.0.1", 0), DashboardHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield f"http://127.0.0.1:{server.server_address[1]}"
+        finally:
+            server.shutdown()
+            server.server_close()
+
+
+def _get_json(base: str) -> dict:
+    with urllib.request.urlopen(f"{base}/api/status", timeout=5) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _get_html(base: str) -> str:
+    with urllib.request.urlopen(f"{base}/", timeout=5) as resp:
+        return resp.read().decode("utf-8")
+
+
+def test_api_status_returns_status_pt_for_on_front(tmp_path):
+    """HTTP seam: an on_front row reports status_pt "na fronteira" with the
+    canonical English status intact in the /api/status payload."""
+    with _live_server(tmp_path, _sample_rows()) as base:
+        payload = _get_json(base)
+
+    trials = {t["status"]: t for t in payload["trials"]}
+    on_front = trials["on_front"]
+
+    assert on_front["status_pt"] == "na fronteira"
+    assert on_front["status_color"] == "#0a7a2f"
+    # Canonical English label is the source of truth and stays untouched.
+    assert on_front["status"] == "on_front"
+
+
+@pytest.mark.parametrize(("canonical", "label", "color"), _STATUS_PT)
+def test_status_pt_localizes_every_canonical_status(tmp_path, canonical, label, color):
+    """Every canonical ADR 0006 status maps to its pt-BR pill label + color,
+    and the canonical English label is preserved unchanged."""
+    with _live_server(tmp_path, _sample_rows()) as base:
+        payload = _get_json(base)
+
+    by_status = {t["status"]: t for t in payload["trials"]}
+    assert by_status[canonical]["status_pt"] == label
+    assert by_status[canonical]["status_color"] == color
+    # Canonical status is never mutated by the pt-BR presentation layer.
+    assert by_status[canonical]["status"] == canonical
+
+
+def test_status_pt_helper_falls_back_to_raw_status():
+    """Pure helper: unknown/empty statuses fall back to the raw value, never
+    lose the label."""
+    assert trial_reader.status_pt("on_front") == "na fronteira"
+    assert trial_reader.status_pt("bogus") == "bogus"
+    assert trial_reader.status_pt("") == "—"
+    assert trial_reader.status_pt(None) == "—"
+
+
+def test_canonical_status_survives_localization_helper():
+    """format_trial_for_ui keeps the canonical status and adds status_pt."""
+    formatted = trial_reader.format_trial_for_ui({"status": "on_front"})
+    assert formatted["status"] == "on_front"
+    assert formatted["status_pt"] == "na fronteira"
+
+
+def test_empty_state_stays_pt_br(tmp_path):
+    """The dashboard empty state renders in pt-BR."""
+    with _live_server(tmp_path, []) as base:
+        html = _get_html(base)
+        payload = _get_json(base)
+
+    assert payload["trials"] == []
+    assert "Nenhum dado de Trial encontrado." in html

--- a/ui/server.py
+++ b/ui/server.py
@@ -53,7 +53,11 @@ _HTML = """<!DOCTYPE html>
   body { font-family: system-ui, sans-serif; margin: 1.5rem; }
   table { border-collapse: collapse; width: 100%; font-size: 0.85rem; }
   th, td { border: 1px solid #ccc; padding: 0.35rem 0.5rem; text-align: left; vertical-align: top; }
-  th { background: #f4f4f4; }
+  thead th { position: sticky; top: 0; z-index: 1; background: #f4f4f4; }
+  tbody tr:nth-child(even) { background: #fafafa; }
+  td.num, th.num { text-align: right; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-variant-numeric: tabular-nums; }
+  .pill { display: inline-block; padding: 0.05rem 0.55rem; border-radius: 999px; color: #fff; font-size: 0.72rem; font-weight: 600; white-space: nowrap; }
+  .trunc { max-width: 18rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   dl { display: grid; grid-template-columns: max-content 1fr; gap: 0.25rem 1rem; }
   dt { font-weight: 600; }
   .empty { color: #666; }
@@ -81,9 +85,9 @@ _HTML = """<!DOCTYPE html>
   <table id="trials-table" hidden>
     <thead>
       <tr>
-        <th>Status</th><th>Outcome</th><th>ctx</th><th>TPS</th>
-        <th>agentic</th><th>coding</th><th>memory</th><th>elapsed</th>
-        <th>diagnostic</th><th>description</th>
+        <th>Status</th><th>Outcome</th><th class="num">ctx</th><th class="num">TPS</th>
+        <th class="num">agentic</th><th class="num">coding</th><th class="num">memory</th><th class="num">elapsed</th>
+        <th>description</th>
       </tr>
     </thead>
     <tbody id="trials-body"></tbody>
@@ -150,9 +154,27 @@ _HTML = """<!DOCTYPE html>
     }
   };
 
-  const cell = (text) => {
+  const textCell = (text) => {
     const td = document.createElement('td');
     td.textContent = text == null || text === '' ? '—' : String(text);
+    return td;
+  };
+
+  const numCell = (text) => {
+    const td = document.createElement('td');
+    td.className = 'num';
+    td.textContent = text == null || text === '' ? '—' : String(text);
+    return td;
+  };
+
+  const statusCell = (t) => {
+    const td = document.createElement('td');
+    const label = t.status_pt || (t.status ? t.status : '—');
+    const span = document.createElement('span');
+    span.className = 'pill';
+    span.style.background = t.status_color || '#999999';
+    span.textContent = label;
+    td.appendChild(span);
     return td;
   };
 
@@ -175,9 +197,23 @@ _HTML = """<!DOCTYPE html>
     trialsTable.hidden = false;
     for (const t of trials) {
       const tr = document.createElement('tr');
-      for (const key of ['status','outcome','ctx','tps','agentic','coding','memory','elapsed','diagnostic','description']) {
-        tr.appendChild(cell(t[key]));
+      tr.appendChild(statusCell(t));
+      // Outcome carries the diagnostic as a tooltip.
+      const outcome = textCell(t.outcome);
+      outcome.className = 'trunc';
+      if (t.diagnostic) {
+        outcome.title = t.diagnostic;
       }
+      tr.appendChild(outcome);
+      for (const key of ['ctx','tps','agentic','coding','memory','elapsed']) {
+        tr.appendChild(numCell(t[key]));
+      }
+      const desc = textCell(t.description);
+      desc.className = 'trunc';
+      if (t.description) {
+        desc.title = t.description;
+      }
+      tr.appendChild(desc);
       trialsBody.appendChild(tr);
     }
   };

--- a/ui/trial_reader.py
+++ b/ui/trial_reader.py
@@ -1,10 +1,34 @@
-"""Harness-backed Trials reader for the dashboard (#25)."""
+"""Harness-backed Trials reader for the dashboard (#25).
+
+The canonical ADR 0006 ``status`` (on_front | dominated | incomplete |
+rejected) is passed through untouched. A pure pt-BR presentation mapping adds
+a ``status_pt`` label (and a pill ``status_color``) per row so the dashboard can
+localize the Trial Status column server-side without mutating the payload.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
 from autoresearch.runners import run as run_mod
+
+# pt-BR presentation labels for the canonical ADR 0006 Trial Status values.
+# The English ``status`` key is the source of truth; ``status_pt`` only affects
+# how the dashboard renders the status pill.
+STATUS_PT: dict[str, str] = {
+    "on_front": "na fronteira",
+    "dominated": "dominado",
+    "incomplete": "incompleto",
+    "rejected": "rejeitado",
+}
+
+# Pill accent color per canonical status (CSS custom-property value).
+STATUS_COLOR: dict[str, str] = {
+    "on_front": "#0a7a2f",  # green
+    "dominated": "#666666",  # gray
+    "incomplete": "#b8860b",  # amber
+    "rejected": "#d70018",  # red
+}
 
 
 def read_last_50_trials() -> list[dict[str, str]]:
@@ -16,10 +40,30 @@ def read_last_50_trials() -> list[dict[str, str]]:
     return list(reversed(rows))[:50]
 
 
+def status_pt(status: Any) -> str:
+    """pt-BR presentation label for a canonical ADR 0006 status.
+
+    Unknown/empty values fall back to the raw status so the label is never
+    lost. This is the pure server-side localization helper.
+    """
+    key = (status or "").strip()
+    return STATUS_PT.get(key, key or "—")
+
+
+def status_color(status: Any) -> str:
+    """Pill accent color for a canonical ADR 0006 status (default gray)."""
+    key = (status or "").strip()
+    return STATUS_COLOR.get(key, "#999999")
+
+
 def format_trial_for_ui(row: dict[str, str]) -> dict[str, Any]:
-    """Operator columns; pass through ADR 0006 status as stored."""
+    """Operator columns; pass through ADR 0006 ``status`` as stored and add the
+    pt-BR ``status_pt`` presentation field (+ pill ``status_color``)."""
+    status = row.get("status") or ""
     return {
-        "status": row.get("status") or "",
+        "status": status,
+        "status_pt": status_pt(status),
+        "status_color": status_color(status),
         "outcome": row.get("outcome") or "",
         "ctx": row.get("ctx") or "",
         "tps": row.get("tps") or "",


### PR DESCRIPTION
Closes #46 — Dashboard T3: Trials table pt-BR status localization.

Localize Trial Status server-side in the read-only operator dashboard:

- `format_trial_for_ui` keeps the canonical ADR 0006 English `status` in the `/api/status` payload and adds a `status_pt` presentation field + `status_color` pill.
- pt-BR mapping: `on_front`→"na fronteira" (green), `dominated`→"dominado" (gray), `incomplete`→"incompleto" (amber), `rejected`→"rejeitado" (red).
- Trials table: 9 columns (status pill, outcome+diagnostic tooltip, ctx, tps, agentic, coding, memory, elapsed, truncated description+tooltip); sticky header, subtle zebra striping, right-aligned monospace tabular numbers; pt-BR empty state.

Tests: `tests/test_ui_dashboard.py` spins up a live `ThreadingHTTPServer` against `DashboardHandler` and asserts `/api/status` returns `status_pt: "na fronteira"` for an `on_front` row with the canonical `status` intact, plus full 4-status localization coverage, helper fallback, and the pt-BR empty state. Passes `ruff check` + `ruff format --check`.