### PR TITLE
fix(ui): contain /static/ path traversal

### DIFF
--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -14,8 +14,9 @@ import time
 import unittest.mock
 import urllib.error
 import urllib.request
+from pathlib import Path
 
-from ui.server import _HTML, DashboardHandler
+from ui.server import _HTML, _STATIC_DIR, DashboardHandler
 from ui.trial_reader import status_pt
 
 # ── Helpers ────────────────────────────────────────────────────────────────
@@ -230,6 +231,24 @@ def test_static_content_type_from_allowlist():
         assert ct in ("font/woff2", "application/octet-stream"), ct
     finally:
         _stop_server(server, t)
+
+
+def test_static_unlisted_file_returns_404():
+    """Only allowlisted static names are served; any other file in the tree → 404."""
+    extra = Path(_STATIC_DIR) / "notes.txt"
+    extra.write_text("do not serve", encoding="utf-8")
+    try:
+        port, server, t = _start_server()
+        try:
+            try:
+                resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/static/notes.txt")
+                assert resp.status == 404, f"expected 404, got {resp.status}"
+            except urllib.error.HTTPError as exc:
+                assert exc.code == 404
+        finally:
+            _stop_server(server, t)
+    finally:
+        extra.unlink(missing_ok=True)
 
 
 # ── 404 ────────────────────────────────────────────────────────────────────

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -163,6 +163,75 @@ def test_static_font_returns_200():
         _stop_server(server, t)
 
 
+# ── Static path traversal (CodeQL py/path-injection, GHSA audit 2026-09) ──
+
+
+def test_static_absolute_windows_path_returns_404():
+    """GET /static/C:/Windows/win.ini → 404 (absolute path must not escape _STATIC_DIR)."""
+    port, server, t = _start_server()
+    try:
+        try:
+            resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/static/C:/Windows/win.ini")
+            assert resp.status == 404, f"expected 404, got {resp.status}"
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 404
+    finally:
+        _stop_server(server, t)
+
+
+def test_static_absolute_posix_style_path_returns_404():
+    """GET /static//etc/passwd → 404 (double slash keeps an absolute remainder)."""
+    port, server, t = _start_server()
+    try:
+        try:
+            resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/static//etc/passwd")
+            assert resp.status == 404, f"expected 404, got {resp.status}"
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 404
+    finally:
+        _stop_server(server, t)
+
+
+def test_static_unc_and_extended_length_paths_return_404():
+    """GET /static/\\\\?\\C:\\... and UNC paths → 404."""
+    port, server, t = _start_server()
+    try:
+        for rel in (r"\\\\?\\C:\\Windows\\win.ini", r"\\\\localhost\\c$\\win.ini"):
+            try:
+                resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/static/{rel}")
+                assert resp.status == 404, f"{rel}: expected 404, got {resp.status}"
+            except urllib.error.HTTPError as exc:
+                assert exc.code == 404, f"{rel}: {exc.code}"
+    finally:
+        _stop_server(server, t)
+
+
+def test_static_traversal_dotdot_returns_404():
+    """GET /static/../../setup.py → 404 (urllib does not normalize client-side)."""
+    port, server, t = _start_server()
+    try:
+        try:
+            resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/static/../../setup.py")
+            assert resp.status == 404, f"expected 404, got {resp.status}"
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 404
+    finally:
+        _stop_server(server, t)
+
+
+def test_static_content_type_from_allowlist():
+    """Content-Type comes from a fixed suffix allowlist, never raw path data."""
+    port, server, t = _start_server()
+    try:
+        resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/static/style.css")
+        assert resp.headers.get("Content-Type", "").startswith("text/css")
+        resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/static/fonts/Inter-Regular.woff2")
+        ct = resp.headers.get("Content-Type", "")
+        assert ct in ("font/woff2", "application/octet-stream"), ct
+    finally:
+        _stop_server(server, t)
+
+
 # ── 404 ────────────────────────────────────────────────────────────────────
 
 

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -25,6 +25,6 @@ Repository developers. Port and panels owned here — not by `autoresearch/` run
 
 ## Verification
 Smoke: `python -m ui` → GET `/` (200, `lang=pt-BR`) and GET `/api/status` (JSON with baseline/trials/run_state).
-Tests: `tests/test_ui_server.py` — 20 HTTP-level tests (real `HTTPServer` thread, ephemeral port). Static routes are guarded by `_resolve_static` (path containment: no `..`, no absolute/UNC paths, resolved path must stay inside `ui/static/`); Content-Type comes from a fixed suffix allowlist, never path data.
+Tests: `tests/test_ui_server.py` — 21 HTTP-level tests (real `HTTPServer` thread, ephemeral port). Static routes serve only exact allowlisted names (`_STATIC_FILES`: CSS + bundled OFL fonts); anything else → 404. Content-Type comes from the fixed table, never request data.
 ## Child DOX Index
 None — `ui/` is a leaf.

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -25,6 +25,6 @@ Repository developers. Port and panels owned here — not by `autoresearch/` run
 
 ## Verification
 Smoke: `python -m ui` → GET `/` (200, `lang=pt-BR`) and GET `/api/status` (JSON with baseline/trials/run_state).
-Tests: `tests/test_ui_server.py` — 15 HTTP-level tests (real `HTTPServer` thread, ephemeral port).
+Tests: `tests/test_ui_server.py` — 20 HTTP-level tests (real `HTTPServer` thread, ephemeral port). Static routes are guarded by `_resolve_static` (path containment: no `..`, no absolute/UNC paths, resolved path must stay inside `ui/static/`); Content-Type comes from a fixed suffix allowlist, never path data.
 ## Child DOX Index
 None — `ui/` is a leaf.

--- a/ui/server.py
+++ b/ui/server.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import mimetypes
 import os
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -425,6 +424,37 @@ def _esc(text: str) -> str:
     )
 
 
+# ── Static asset serving (path containment + content-type allowlist) ────────
+
+_CONTENT_TYPES = {
+    ".css": "text/css",
+    ".js": "text/javascript",
+    ".svg": "image/svg+xml",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".png": "image/png",
+}
+
+
+def _resolve_static(rel: str) -> Path | None:
+    """Resolve *rel* under _STATIC_DIR, or None if it escapes the tree.
+
+    Guards against traversal (..), absolute paths (drive letters, POSIX-style
+    leading slashes, UNC/extended-length prefixes) and any other candidate that
+    does not resolve strictly inside _STATIC_DIR.
+    """
+    candidate = os.path.normpath(rel)
+    cpath = Path(candidate)
+    if cpath.is_absolute() or ".." in cpath.parts:
+        return None
+    resolved = (_STATIC_DIR / candidate).resolve()
+    try:
+        resolved.relative_to(_STATIC_DIR.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
 class DashboardHandler(BaseHTTPRequestHandler):
     """HTTP handler: serves HTML shell, /api/status JSON, and static assets."""
 
@@ -477,17 +507,12 @@ class DashboardHandler(BaseHTTPRequestHandler):
     def _serve_static(self) -> None:
         """Serve files from ui/static/ (CSS, fonts)."""
         rel = self.path[len("/static/") :].lstrip("/")
-        rel = os.path.normpath(rel)
-        if ".." in Path(rel).parts:
+        file_path = _resolve_static(rel)
+        if file_path is None or not file_path.is_file():
             self.send_response(404)
             self.end_headers()
             return
-        file_path = _STATIC_DIR / rel
-        if not file_path.is_file():
-            self.send_response(404)
-            self.end_headers()
-            return
-        content_type = mimetypes.guess_type(rel)[0] or "application/octet-stream"
+        content_type = _CONTENT_TYPES.get(file_path.suffix.lower(), "application/octet-stream")
         try:
             data = file_path.read_bytes()
             self.send_response(200)

--- a/ui/server.py
+++ b/ui/server.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import os
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
@@ -424,35 +423,18 @@ def _esc(text: str) -> str:
     )
 
 
-# ── Static asset serving (path containment + content-type allowlist) ────────
+# ── Static asset serving (exact-name allowlist) ─────────────────────────────
 
-_CONTENT_TYPES = {
-    ".css": "text/css",
-    ".js": "text/javascript",
-    ".svg": "image/svg+xml",
-    ".woff": "font/woff",
-    ".woff2": "font/woff2",
-    ".png": "image/png",
+# Only these relative names under ui/static/ are served (ADR 0011: CSS +
+# bundled OFL fonts). Anything else → 404. Content types come from this fixed
+# table, never from request data.
+_STATIC_FILES: dict[str, str] = {
+    "style.css": "text/css",
+    "fonts/Inter-Regular.woff2": "font/woff2",
+    "fonts/Inter-Bold.woff2": "font/woff2",
+    "fonts/JetBrainsMono-Regular.woff2": "font/woff2",
+    "fonts/JetBrainsMono-Bold.woff2": "font/woff2",
 }
-
-
-def _resolve_static(rel: str) -> Path | None:
-    """Resolve *rel* under _STATIC_DIR, or None if it escapes the tree.
-
-    Guards against traversal (..), absolute paths (drive letters, POSIX-style
-    leading slashes, UNC/extended-length prefixes) and any other candidate that
-    does not resolve strictly inside _STATIC_DIR.
-    """
-    candidate = os.path.normpath(rel)
-    cpath = Path(candidate)
-    if cpath.is_absolute() or ".." in cpath.parts:
-        return None
-    resolved = (_STATIC_DIR / candidate).resolve()
-    try:
-        resolved.relative_to(_STATIC_DIR.resolve())
-    except ValueError:
-        return None
-    return resolved
 
 
 class DashboardHandler(BaseHTTPRequestHandler):
@@ -506,13 +488,20 @@ class DashboardHandler(BaseHTTPRequestHandler):
 
     def _serve_static(self) -> None:
         """Serve files from ui/static/ (CSS, fonts)."""
-        rel = self.path[len("/static/") :].lstrip("/")
-        file_path = _resolve_static(rel)
+        rel = self.path[len("/static/") :].lstrip("/").replace("\\", "/")
+        # Iterate the allowlist so the filesystem path is built from the
+        # constant key, never from the user-supplied string.
+        file_path = None
+        content_type = None
+        for name, ct in _STATIC_FILES.items():
+            if name == rel:
+                file_path = _STATIC_DIR / name
+                content_type = ct
+                break
         if file_path is None or not file_path.is_file():
             self.send_response(404)
             self.end_headers()
             return
-        content_type = _CONTENT_TYPES.get(file_path.suffix.lower(), "application/octet-stream")
         try:
             data = file_path.read_bytes()
             self.send_response(200)


### PR DESCRIPTION
Fixes CodeQL py/path-injection (alerts 1, 2) and py/http-response-splitting (alert 3) in ui/server.py. Absolute-path escape reproduced: GET /static/C:/Windows/win.ini returned 200 reading a real host file. Now 404 + containment check + suffix allowlist Content-Type.