### PR TITLE
refactor(classify): shared known_vectors helper + DOX index for ADR 0017 (PR #71 review follow-up)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,9 +2,12 @@ name: validate
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
+
+# Same branch pushed + PR-opened = two events; keep only the newest run.
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:

--- a/autoloop.py
+++ b/autoloop.py
@@ -532,23 +532,12 @@ def _objective_vector(cfg: dict[str, Any], res) -> classify.ObjectiveVector:
 def _seed_known_vectors(model_name: str, bucket_gb: int | None) -> list[classify.ObjectiveVector]:
     """Complete known vectors for one model, scoped to a hardware+budget bucket.
 
-    Mirrors ``classify._known_vectors`` so the search front matches the store's
-    classification: same model, same bucket, rejected rows never compete, and
-    repeated measurements of one basename merge to a best-of-each-axis vector.
+    ADR 0017 Known-Set shape via ``classify.known_vectors`` — one filter/merge
+    implementation shared with the store's classification, not a mirror:
+    same basename, same bucket, rejected rows never compete, Morris screen
+    rows are diagnostic-only, and repeated measurements merge per-axis.
     """
-    vectors: list[classify.ObjectiveVector] = []
-    for row in read_rows(RESULTS_FILE):
-        if (
-            row.get("status") == "rejected"
-            or (row.get("evaluation_profile") or "").strip() == MORRIS_SCREEN_PROFILE
-            or (row.get("model") or "").strip() != model_name
-        ):
-            continue
-        if bucket_gb is not None and classify.row_bucket(row) != bucket_gb:
-            continue
-        vectors.append(classify.vector_from_row(row))
-    merged = classify.merge([classify.Trial(fp=model_name, vector=v) for v in vectors])
-    return [trial.vector for trial in merged if trial.vector.complete]
+    return classify.known_vectors(read_rows(RESULTS_FILE), model=model_name, bucket_gb=bucket_gb)
 
 
 def _classify(cfg: dict[str, Any], res) -> tuple[str, dict[str, str], classify.ObjectiveVector]:
@@ -907,7 +896,7 @@ def main():
             break
 
         # Seed the per-model front from the results store, scoped to this
-        # hardware+budget bucket (mirrors classify._known_vectors) so Neighbor
+        # hardware+budget bucket (via classify.known_vectors, ADR 0017) so Neighbor
         # acceptance sees prior sessions' points, not an empty session-local front.
         baseline_now = state_manager.get_baseline()
         vram_limit = baseline_now.get("VRAM_LIMIT_MB")

--- a/autoresearch/core/classify.py
+++ b/autoresearch/core/classify.py
@@ -115,6 +115,31 @@ def classify_trial(
     return "on_front"
 
 
+def known_vectors(
+    rows: Sequence[Mapping[str, Any]], *, model: str, bucket_gb: int | None
+) -> list[ObjectiveVector]:
+    """Complete merged points for ONE basename in a hardware+budget bucket.
+
+    ADR 0017 Known-Set shape shared by classify and autoloop's Search seed:
+    rejected rows never compete, Morris screen points are diagnostic-only
+    (ADR 0016), and repeated measurements of one basename merge to a
+    best-of-each-axis vector. ``bucket_gb=None`` means no bucket filter.
+    """
+    vectors: list[ObjectiveVector] = []
+    for row in rows:
+        if row.get("status") == "rejected":
+            continue  # rejected Trials never compete for the front
+        if (row.get("evaluation_profile") or "").strip() == MORRIS_SCREEN_PROFILE:
+            continue  # Morris screen points are diagnostic, never front seeds
+        if (row.get("model") or "").strip() != model:
+            continue
+        if bucket_gb is not None and row_bucket(row) != bucket_gb:
+            continue
+        vectors.append(vector_from_row(row))
+    merged = merge([Trial(fp=model, vector=v) for v in vectors])
+    return [trial.vector for trial in merged if trial.vector.complete]
+
+
 def _known_vectors(
     rows: Sequence[Mapping[str, Any]],
     bucket_gb: int,
@@ -127,6 +152,8 @@ def _known_vectors(
     to the Trial's own basename — a stronger model never demotes another
     model; only same-basename configs compete.
     """
+    if model is not None:
+        return known_vectors(rows, model=model, bucket_gb=bucket_gb)
     by_model: dict[str, list[ObjectiveVector]] = {}
     for row in rows:
         if row.get("status") == "rejected":

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -37,7 +37,7 @@ Durable documentation for this repo: model cards, technique notes, architecture 
 
 ## Child DOX Index
 - [docs/models/AGENTS.md](models/AGENTS.md) — model card schema + per-model index.
-- [docs/adr/AGENTS.md](adr/AGENTS.md) — architecture decision records contract + index (ADRs 0001–0016).
+- [docs/adr/AGENTS.md](adr/AGENTS.md) — architecture decision records contract + index (ADRs 0001–0017).
 - [docs/discovery/AGENTS.md](discovery/AGENTS.md) — user-facing guides (tooling, quantization, CPU inference, inference engines, speculative formats).
 - [docs/sessions/AGENTS.md](sessions/AGENTS.md) — single-day empirical session logs index (2026-06-19 onward).
 - [docs/architecture.html](architecture.html) — interactive architecture diagram (HTML exception under docs/).

--- a/docs/adr/AGENTS.md
+++ b/docs/adr/AGENTS.md
@@ -44,3 +44,4 @@ Durable record of architecture decisions for the `local-model-autotuning` projec
 - [`0014-fingerprint-bus-product-split.md`](./0014-fingerprint-bus-product-split.md) — Fingerprint bus; TPS-then-Pi journey; Pareto Set remains a report; `teach/` frozen.
 - [`0015-rocm-first-binary-resolution-windows.md`](./0015-rocm-first-binary-resolution-windows.md) — ROCm-first binary resolution on Windows; Vulkan0 hardcode removal; `--no-reasoning-preserve` fix.
 - [`0016-measurement-hygiene-and-morris-screen.md`](./0016-measurement-hygiene-and-morris-screen.md) — Thermal settle, TPS median, crash journal, Morris engine-knob pin; Neighbor Search unchanged.
+- [`0017-rank-membership-quality-first.md`](./0017-rank-membership-quality-first.md) — Rank = leaderboard (every complete model once, quality-first, near-tie band); domination is a same-basename config label; cross-model `dominated` ceases (supersedes part of 0006/0009/0013).

--- a/tests/test_autoloop.py
+++ b/tests/test_autoloop.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import autoloop
+from autoresearch.core import classify
 from autoresearch.core.search import SearchStrategy
 
 
@@ -73,6 +74,43 @@ class TestAutoLoop(unittest.TestCase):
             vectors = autoloop._seed_known_vectors("a.gguf", bucket_gb=8)
         self.assertEqual(len(vectors), 1)
         self.assertEqual(vectors[0].tps, 50.0)
+
+    def test_seed_known_vectors_matches_classify_known_vectors(self):
+        # ADR 0017 dedup (review of PR #71, Standards Finding 2): the autoloop
+        # Search seed IS the classify Known Set — delegation, not a mirror.
+        rows = [
+            {
+                "model": "a.gguf",
+                "status": "on_front",
+                "ctx": "8192",
+                "tps": "50.0",
+                "agentic": "0.5",
+                "coding": "0.6",
+                "config_json": '{"vram_limit_mb": 8192}',
+            },
+            {
+                "model": "b.gguf",
+                "status": "on_front",
+                "ctx": "8192",
+                "tps": "99.0",
+                "agentic": "0.9",
+                "coding": "0.9",
+                "config_json": '{"vram_limit_mb": 8192}',
+            },
+            {
+                "model": "a.gguf",
+                "status": "on_front",
+                "ctx": "8192",
+                "tps": "99.0",
+                "agentic": "0.9",
+                "coding": "0.9",
+                "evaluation_profile": "morris-screen",
+            },
+        ]
+        with patch("autoloop.read_rows", return_value=rows):
+            seeded = autoloop._seed_known_vectors("a.gguf", bucket_gb=8)
+        self.assertEqual(seeded, classify.known_vectors(rows, model="a.gguf", bucket_gb=8))
+        self.assertEqual(len(seeded), 1)
 
     def test_seed_known_vectors_skips_morris_screen_rows(self):
         rows = [

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 from autoresearch.core.classify import (
+    _known_vectors,
     bucket,
     classify_trial,
     fp_from_baseline,
@@ -172,6 +173,109 @@ def test_plan_write_known_set_scoped_to_own_basename():
     )
     assert status == "on_front"
     assert flips == {}
+
+
+def test_plan_write_same_basename_weaker_config_shares_prior_front():
+    # Pin (AC #3 semantics, review of PR #71): plan_write never returns
+    # `dominated` for a same-basename config — competition inside one basename
+    # is the merge (componentwise max); a strictly weaker config still shares
+    # the front. Cross-config verdicts live in hill-climb bookkeeping.
+    fp = fp_from_baseline(BASELINE)
+    stronger = row(
+        trial_id="cfg1",
+        model="M.gguf",
+        status="on_front",
+        config_json=cfg_json(dict(BASELINE, THREADS=8)),
+        ctx="131072",
+        tps="40.0",
+        agentic="0.7",
+        coding="0.7",
+    )
+    status, flips = plan_write(
+        [stronger],
+        fp=fp,
+        vector=v(ctx=65536, tps=20.0, agentic=0.4, coding=0.4),
+        bucket_gb=8,
+        model="M.gguf",
+    )
+    assert status == "on_front"  # merged vector == prior; dominated unreachable
+    assert flips == {}
+
+
+def test_known_vectors_public_helper_matches_scoped_known_set():
+    # ADR 0017 dedup (review of PR #71, Standards Finding 2): one filter/merge
+    # shape for the Known Set — autoloop's Search seed goes through the same
+    # public helper classify uses, not a mirror re-implementation.
+    rows = [
+        row(
+            trial_id="a",
+            model="M.gguf",
+            status="on_front",
+            ctx="131072",
+            tps="40.0",
+            agentic="0.7",
+            coding="0.7",
+        ),
+        row(
+            trial_id="b",
+            model="M.gguf",
+            status="on_front",
+            ctx="65536",
+            tps="50.0",
+            agentic="",
+            coding="",
+        ),
+        row(
+            trial_id="c",
+            model="Other.gguf",
+            status="on_front",
+            ctx="131072",
+            tps="99.0",
+            agentic="0.9",
+            coding="0.9",
+        ),
+        row(
+            trial_id="d",
+            model="M.gguf",
+            status="rejected",
+            ctx="131072",
+            tps="70.0",
+            agentic="0.9",
+            coding="0.9",
+        ),
+        row(
+            trial_id="e",
+            model="M.gguf",
+            status="on_front",
+            ctx="131072",
+            tps="99.0",
+            agentic="0.9",
+            coding="0.9",
+            evaluation_profile="morris-screen",
+        ),
+        row(
+            trial_id="f",
+            model="M.gguf",
+            status="on_front",
+            config_json=cfg_json(dict(BASELINE, VRAM_LIMIT_MB=6144)),
+            ctx="131072",
+            tps="99.0",
+            agentic="0.9",
+            coding="0.9",
+        ),
+    ]
+    from autoresearch.core.classify import known_vectors
+
+    assert known_vectors(rows, model="M.gguf", bucket_gb=8) == _known_vectors(
+        rows, 8, model="M.gguf"
+    )
+    # Other basename excluded; rejected/Morris/6-GiB rows excluded; the two
+    # same-bucket on_front rows merge to best-of-each-axis.
+    known = known_vectors(rows, model="M.gguf", bucket_gb=8)
+    assert len(known) == 1
+    assert known[0].complete
+    assert known[0].tps == 50.0
+    assert known[0].agentic == 0.7
 
 
 def test_plan_write_same_basename_better_config_merges_to_on_front():


### PR DESCRIPTION
Addresses the two-axis review findings of PR #71 (issue #68). Note: main (d290416) already carries the evolved #68 implementation, so findings were fixed here on top of main; PR #71 itself is superseded and can be closed.

## Standards F1 (P1, hard) — stale Child DOX Index
- `docs/adr/AGENTS.md` index gains ADR 0017 entry; `docs/AGENTS.md` updated to 0001–0017.

## Standards F2 (smell) — Duplicated Code
- `autoloop._seed_known_vectors` re-implemented the Known-Set filter/merge shape ("Mirrors classify._known_vectors" comment). Now exposes public `classify.known_vectors(rows, *, model, bucket_gb)`; autoloop delegates; `_known_vectors`' model branch routes through the same helper. One filter/merge shape, two callers.

## Spec F3 (P1) — AC #3 pin
- New test pins that `plan_write` never returns `dominated` for a same-basename config: intra-basename competition is the merge (componentwise max); cross-config verdicts stay in hill-climb bookkeeping (search.py).

## Deliberately not addressed
- Morris prior-merge immunity gap in `plan_write` flips/prior filters: pre-existing, out of #68 scope — separate behavior change if wanted.

## Verification
- Proof mode: 3 failing tests first (ImportError/AttributeError on `known_vectors`), then implementation.
- Full local suite: 687 passed, 3 skipped (live trial server previously tripped 2 single-load gate tests; port freed before commit).
- ruff check + format clean; pre-commit hooks green on both commits.